### PR TITLE
Tiny bug in documentation.

### DIFF
--- a/docs/src/clouds/appendix.html
+++ b/docs/src/clouds/appendix.html
@@ -416,7 +416,6 @@ _EXAMPLE_CMD_END
         &lt;pathOnVM&gt;/tmp/customizedfile&lt;/pathOnVM&gt;
     &lt;/filewrite&gt;
 &lt;/OptionalParameters&gt;
-&lt;/pre&gt;
 </pre>
 
 <p>


### PR DESCRIPTION
There was a fake pre tag in the appendix.
