### PR TITLE
Add ability to specify multiple allowed CPU architectures 

### DIFF
--- a/messaging/gt4.0/java/msgbridge/src/org/nimbustools/messaging/gt4_0/factory/FactoryResource.java
+++ b/messaging/gt4.0/java/msgbridge/src/org/nimbustools/messaging/gt4_0/factory/FactoryResource.java
@@ -385,9 +385,9 @@ public class FactoryResource implements ResourceProperties, Resource {
         
         /* CPUArchitectureName */
 
-        if (advert.getCpuArchitectureName() != null) {
+        if (advert.getCpuArchitectureNames() != null) {
             prop = new SimpleResourceProperty(Constants_GT4_0.RP_FACTORY_CPUArch);
-            prop.add(advert.getCpuArchitectureName());
+            prop.add(advert.getCpuArchitectureNames());
             this.propSet.add(prop);
         }
 

--- a/service-api/java/source/src/org/nimbustools/api/_repr/_Advertised.java
+++ b/service-api/java/source/src/org/nimbustools/api/_repr/_Advertised.java
@@ -22,7 +22,7 @@ public interface _Advertised extends Advertised {
 
     public void setDefaultRunningTimeSeconds(int defaultRunningTime);
     public void setMaximumRunningTimeSeconds(int maximumRunningTime);
-    public void setCpuArchitectureName(String cpuArchitectureName);
+    public void setCpuArchitectureNames(String[] cpuArchitectureNames);
     public void setVmmVersions(String[] vmmVersions);
     public void setVmm(String vmm);
     public void setNetworkNames(String[] networkNames);

--- a/service-api/java/source/src/org/nimbustools/api/defaults/repr/DefaultAdvertised.java
+++ b/service-api/java/source/src/org/nimbustools/api/defaults/repr/DefaultAdvertised.java
@@ -29,7 +29,7 @@ public class DefaultAdvertised implements _Advertised {
     private int defaultRunningTimeSeconds;
     private int maximumRunningTimeSeconds;
     private int maximumAfterRunningTimeSeconds;
-    private String cpuArchitectureName;
+    private String[] cpuArchitectureNames;
     private String[] vmmVersions;
     private String vmm;
     private String[] networkNames;
@@ -53,8 +53,8 @@ public class DefaultAdvertised implements _Advertised {
         return this.maximumAfterRunningTimeSeconds;
     }
 
-    public String getCpuArchitectureName() {
-        return this.cpuArchitectureName;
+    public String[] getCpuArchitectureNames() {
+        return this.cpuArchitectureNames;
     }
 
     public String[] getVmmVersions() {
@@ -94,8 +94,8 @@ public class DefaultAdvertised implements _Advertised {
         this.maximumAfterRunningTimeSeconds = maximumAfterRunningTime;
     }
 
-    public void setCpuArchitectureName(String cpuArchitectureName) {
-        this.cpuArchitectureName = cpuArchitectureName;
+    public void setCpuArchitectureNames(String[] cpuArchitectureNames) {
+        this.cpuArchitectureNames = cpuArchitectureNames;
     }
 
     public void setVmmVersions(String[] vmmVersions) {
@@ -129,7 +129,8 @@ public class DefaultAdvertised implements _Advertised {
                 ", maximumRunningTimeSeconds=" + maximumRunningTimeSeconds +
                 ", maximumAfterRunningTimeSeconds=" +
                 maximumAfterRunningTimeSeconds +
-                ", cpuArchitectureName='" + cpuArchitectureName + '\'' +
+                ", cpuArchitectureNames='" +
+                (cpuArchitectureNames  == null ? null : Arrays.asList(cpuArchitectureNames)) +
                 ", vmmVersions=" +
                 (vmmVersions == null ? null : Arrays.asList(vmmVersions)) +
                 ", vmm='" + vmm + '\'' +

--- a/service-api/java/source/src/org/nimbustools/api/repr/Advertised.java
+++ b/service-api/java/source/src/org/nimbustools/api/repr/Advertised.java
@@ -25,7 +25,7 @@ public interface Advertised {
 
     public int getDefaultRunningTimeSeconds();
     public int getMaximumRunningTimeSeconds();
-    public String getCpuArchitectureName();
+    public String[] getCpuArchitectureNames();
     public String[] getVmmVersions();
     public String getVmm();
     public String[] getNetworkNames();

--- a/service/service/java/source/etc/workspace-service/other/main.xml
+++ b/service/service/java/source/etc/workspace-service/other/main.xml
@@ -125,7 +125,7 @@
           init-method="validate">
 
         <!-- Property values coming via vmm.conf -->
-        <property name="cpuArchitectureName"
+        <property name="cpuArchitectureNames"
                   value="$VMM{cpu.arch}" />
         <property name="vmm"
                   value="$VMM{vmm.type}" />

--- a/service/service/java/source/src/org/globus/workspace/creation/defaults/DefaultCreation.java
+++ b/service/service/java/source/src/org/globus/workspace/creation/defaults/DefaultCreation.java
@@ -229,8 +229,8 @@ public class DefaultCreation implements Creation {
     public Advertised getAdvertised() {
 
         final _Advertised adv = this.repr._newAdvertised();
-        adv.setCpuArchitectureName(
-                this.globals.getCpuArchitectureName());
+        adv.setCpuArchitectureNames(
+                this.globals.getCpuArchitectureNames());
         adv.setDefaultRunningTimeSeconds(
                 this.globals.getDefaultRunningTimeSeconds());
         adv.setMaxGroupSize(

--- a/service/service/java/source/src/org/globus/workspace/service/binding/GlobalPolicies.java
+++ b/service/service/java/source/src/org/globus/workspace/service/binding/GlobalPolicies.java
@@ -24,7 +24,7 @@ public interface GlobalPolicies {
 
     public int getTerminationOffsetSeconds();
 
-    public String getCpuArchitectureName();
+    public String[] getCpuArchitectureNames();
 
     public String[] getVmmVersions();
 

--- a/service/service/java/source/src/org/globus/workspace/service/binding/defaults/DefaultGlobalPolicies.java
+++ b/service/service/java/source/src/org/globus/workspace/service/binding/defaults/DefaultGlobalPolicies.java
@@ -38,7 +38,7 @@ public class DefaultGlobalPolicies implements GlobalPolicies {
     private int defaultRunningTimeSeconds;
     private int maximumRunningTimeSeconds;
     private int terminationOffsetSeconds;
-    private String cpuArchitectureName;
+    private String[] cpuArchitectureNames;
     private String[] vmmVersions;
     private String vmm;
 
@@ -83,12 +83,12 @@ public class DefaultGlobalPolicies implements GlobalPolicies {
         this.terminationOffsetSeconds = terminationOffsetSeconds;
     }
 
-    public String getCpuArchitectureName() {
-        return this.cpuArchitectureName;
+    public String[] getCpuArchitectureNames() {
+        return this.cpuArchitectureNames;
     }
 
-    public void setCpuArchitectureName(String cpuArchitectureName) {
-        this.cpuArchitectureName = cpuArchitectureName;
+    public void setCpuArchitectureNames(String[] cpuArchitectureNames) {
+        this.cpuArchitectureNames = cpuArchitectureNames;
     }
 
     public String[] getVmmVersions() {


### PR DESCRIPTION
This patch allows Nimbus administrators to specify multiple permitted CPU architectures in vmm.conf. You can now do this in the same way you can request multiple vmm versions, with a comma separated list. 

Comments welcome.
