### PR TITLE
Adding a partition Label to the created blankspace partition

### DIFF
--- a/control/libexec/workspace-control/blankcreate.sh
+++ b/control/libexec/workspace-control/blankcreate.sh
@@ -23,7 +23,7 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-CMD="/sbin/mke2fs -L blankspce -F $FILE"
+CMD="/sbin/mke2fs -L blankspace -F $FILE"
 echo "          running:  $CMD"
 
 $CMD


### PR DESCRIPTION
A Label on the blankspace partition will allow mounting via Label instead of
device, this makes it easier in fstab where the device of the blankspace partition may change.
