### PR TITLE
Fixed "locahost" typo, removed unnecessary property assignment

### DIFF
--- a/tests/ec2_submit_many.py
+++ b/tests/ec2_submit_many.py
@@ -71,8 +71,7 @@ def main(argv=sys.argv[1:]):
         except:
             pass
 
-        ec2conn = EC2Connection(s3id, pw, host='locahost', port=ec2port, debug=2)
-        ec2conn.host = 'localhost'
+        ec2conn = EC2Connection(s3id, pw, host='localhost', port=ec2port, debug=2)
         print "getting image"
         image = ec2conn.get_image(imagename)
         print "running"


### PR DESCRIPTION
Object creation passed host as "locahost", then it appeared to correct for that by setting the host property on the next line.
