### PR TITLE
Fixing the wget and automake in install process

### DIFF
--- a/cumulus/cumulus-install.sh
+++ b/cumulus/cumulus-install.sh
@@ -139,6 +139,7 @@ if [ $? -ne 0 ]; then
     echo "configure failed"
     exit 1
 fi
+automake --add-missing
 make install
 if [ $? -ne 0 ]; then
     echo "make install failed"

--- a/install
+++ b/install
@@ -93,7 +93,9 @@ echo ""
 pyve_path=$NIMBUS_HOME/ve
 echo "Installing from $NIMBUS_SRC"
 
+#not working
 cp $NIMBUS_SRC/cumulus/*.egg .
+
 $PYTHON_EXE $NIMBUS_SRC/cumulus/virtualenv.py --no-site-packages -p $PYTHON_EXE $pyve_path | tee -a $NIMBUS_HOME/install.log
 if [ $PIPESTATUS -ne 0 ]; then
     echo "ERROR: python virtualenv installation failed."

--- a/libexec/create-nimbus-home
+++ b/libexec/create-nimbus-home
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CONTAINER_URL="http://www-unix.globus.org/ftppub/gt4/4.0/4.0.8/ws-core/bin/ws-core-4.0.8-bin.tar.gz"
-CONTAINER_URL="https://github.com/downloads/nimbusproject/nimbus/ws-core-4.0.8-bin.tar.gz"
+CONTAINER_URL="https://cloud.github.com/downloads/nimbusproject/nimbus/ws-core-4.0.8-bin.tar.gz"
 CONTAINER_TARNAME="ws-core-4.0.8-bin.tar.gz"
 CONTAINER_UNTARREDNAME="ws-core-4.0.8"
 
@@ -38,7 +38,8 @@ echo ""
 if [ ! -f $TMPDIR/$CONTAINER_TARNAME ]; then
     echo "Downloading service container.."
     echo ""
-    wget --no-check-certificate -c -O $TMPDIR/$CONTAINER_TARNAME $CONTAINER_URL
+
+    wget --no-check-certificate -c -O $TMPDIR/$CONTAINER_TARNAME $CONTAINER_URL || curl -o "$TMPDIR"/"$CONTAINER_TARNAME" "$CONTAINER_URL"
 
     if [ $? -ne 0 ]; then
     echo ""


### PR DESCRIPTION
The make install in cumulus was complaining because of some missing boilerplate. automake --add-missing will fix them if any on a target system. Added a comment that there are no .egg files in cumulus. Changed the container url to the one that was getting redirected to. Also added curl in case wget fails.
