### PR TITLE
boto 2.3 support

### DIFF
--- a/cumulus/cb/pycb/cumulus.py
+++ b/cumulus/cb/pycb/cumulus.py
@@ -14,6 +14,7 @@ from pycb.cbRequest import cbDeleteObject
 from pycb.cbRequest import cbPutBucket
 from pycb.cbRequest import cbPutObject
 from pycb.cbRequest import cbHeadObject
+from pycb.cbRequest import cbHeadBucket
 from pycb.cbRequest import cbCopyObject
 from pycb.cbRedirector import *
 from datetime import date, datetime
@@ -149,8 +150,11 @@ class CBService(resource.Resource):
             else:
                 cbR = cbDeleteObject(request, user, bucketName, objectName, requestId, pycb.config.bucket)
             return cbR
-        elif request.method == 'HEAD' and objectName != None:
-            cbR = cbHeadObject(request, user, bucketName, objectName, requestId, pycb.config.bucket)
+        elif request.method == 'HEAD':
+            if objectName == None:
+                cbR = cbHeadBucket(request, user, bucketName, requestId, pycb.config.bucket)
+            else:
+                cbR = cbHeadObject(request, user, bucketName, objectName, requestId, pycb.config.bucket)
             return cbR
 
         raise cbException('InvalidArgument')


### PR DESCRIPTION
In boto 2.2.2, a call to S3Connection.get_bucket(BUCKET_NAME) results in a GET request, but in boto 2.32 the same call is now a HEAD request, so save on the bandwidth.

These breaks cumulus.
This is the commit that changed the behavior, in case you're interested: https://github.com/boto/boto/commit/ac7b717d607c9f973245896079312512e77c4cc5
